### PR TITLE
Add resume-after-hibernation service

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 * @dominiksalvet
 
 # systemd, AUR package
-.gitpack/data/asus-fan-control.service @agura-lex
+.gitpack/data/asus-fan-control*.service @agura-lex

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 * @dominiksalvet
 
 # systemd, AUR package
-.gitpack/data/asus-fan-control*.service @agura-lex
+.gitpack/data/*.service @agura-lex

--- a/.gitpack/data/asus-fan-control-resume.service
+++ b/.gitpack/data/asus-fan-control-resume.service
@@ -4,12 +4,12 @@
 #-------------------------------------------------------------------------------
 
 [Unit]
-Description=Fan control for ASUS devices running Linux.
+Description=Run asus-fan-control after resuming from hibernate.
+After=hibernate.target
 
 [Service]
 Type=oneshot
 ExecStart=/usr/local/bin/asus-fan-control
 
 [Install]
-WantedBy=multi-user.target
-Also=asus-fan-control-resume.service
+WantedBy=hibernate.target

--- a/.gitpack/install/global-Linux/map
+++ b/.gitpack/install/global-Linux/map
@@ -2,3 +2,4 @@ src/asus-fan-control /usr/local/bin
 src/asus-fan-control-completion /etc/bash_completion.d
 data/default-temps /usr/share/asus-fan-control
 .gitpack/data/asus-fan-control.service /etc/systemd/system
+.gitpack/data/asus-fan-control-resume.service /etc/systemd/system

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 The changes not yet present in any release are listed in this section.
 
-### Added
+### Fixed
 
-* Systemd service to run asus-fan-control on resume from hibernate
+* Systemd service runs asus-fan-control on resume from hibernate.
 
 ## 2.12.0 (2019-12-29)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 The changes not yet present in any release are listed in this section.
 
+### Added
+
+* Systemd service to run asus-fan-control on resume from hibernate
+
 ## 2.12.0 (2019-12-29)
 
 ### Added


### PR DESCRIPTION
**Description**
Add systemd service to run asus-fan-control on resume from hibernate, it should be pulled as a dependency for the `asus-fan-control.service`

**Additional context**
Addresses https://github.com/dominiksalvet/asus-fan-control/issues/13
