### PR TITLE
Fix warning: command substitution: ignored null byte in input

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,10 @@ The changes not yet present in any release are listed in this section.
 
 * Adapt to new GitPack 1.0.0 installation format.
 
+### Fixed
+
+* Fixed `ignored null byte in input` warning occurring on some systems.
+
 ## 3.9.0 (2020-10-24)
 
 ### Added

--- a/src/asus-fan-control
+++ b/src/asus-fan-control
@@ -432,7 +432,7 @@ read_acpi_temp() (
 # DESCRIPTION:
 #   Reads and prints the previous ACPI call result, fails on detected errors.
 get_acpi_result() (
-    result="$(cat "$ACPI_CALL_PATH")" &&
+    result="$(tr -d '\0' < "$ACPI_CALL_PATH")" &&
 
     if echo "$result" | grep -qi error; then
         echo "acpi call failed with '$result'" >&2; return 1


### PR DESCRIPTION
**Description**
Fix warning: command substitution: ignored null byte in input


**Additional context**
Solve issue: https://github.com/dominiksalvet/asus-fan-control/issues/77

