### PR TITLE
Change the systemctl service name to match the one installed

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -86,7 +86,7 @@ sudo makepkg -si
 It may be a good idea to also enable running asus-fan-control automatically:
 
 ```sh
-sudo systemctl enable asus-fan-control
+sudo systemctl enable afc
 ```
 
 ## Usage


### PR DESCRIPTION
The installation guide refers a service name that is different from the name of the actual service installed, resulting in a "service could not be found" error.

**Description**
Describe the problem and your solution.

**Additional context**
Add related issues and any other context.
